### PR TITLE
docs(security):Cookie of token, the key must be csrfToken,

### DIFF
--- a/docs/source/zh-cn/core/security.md
+++ b/docs/source/zh-cn/core/security.md
@@ -300,7 +300,7 @@ module.exports = {
 In jQuery:
 
 ```js
-var csrftoken = Cookies.get('csrftoken');
+var csrftoken = Cookies.get('csrfToken');
 
 function csrfSafeMethod(method) {
   // these HTTP methods do not require CSRF protection


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
The code example about CSRF for AJAX In jQuery, to get token from cookie, should be Cookies.get('csrfToken'), cause the default cookieName u set is 'csrfToken', ^_^.